### PR TITLE
Added test for search text-based ids.

### DIFF
--- a/tests/xapian_tests/models.py
+++ b/tests/xapian_tests/models.py
@@ -43,9 +43,5 @@ class BlogEntry(AbstractBlogEntry):
     pass
 
 
-class UUIDBlogEntry(AbstractBlogEntry):
-    """
-    A blog entry with string based primary key instead of an integer.
-    Covers #138
-    """
+class UUIDModel(models.Model):
     uuid = models.CharField(primary_key=True, max_length=20)

--- a/tests/xapian_tests/search_indexes.py
+++ b/tests/xapian_tests/search_indexes.py
@@ -82,33 +82,11 @@ class BlogSearchIndex(indexes.SearchIndex):
         return ''
 
 
-class UUIDBlogSearchIndex(BlogSearchIndex):
+class UUIDModelSearchIndex(indexes.SearchIndex):
+    text = indexes.CharField(document=True)
 
     def get_model(self):
-        return models.UUIDBlogEntry
-
-    def prepare_sites(self, obj):
-        return ['%d' % (i * int(obj.pk.split('-')[1])) for i in range(1, 4)]
-
-    def prepare_tags(self, obj):
-        if obj.pk == 'uuid-1':
-            return ['a', 'b', 'c']
-        elif obj.pk == 'uuid-2':
-            return ['ab', 'bc', 'cd']
-        else:
-            return ['an', 'to', 'or']
-
-    def prepare_keys(self, obj):
-        return [i * int(obj.pk.split('-')[1]) for i in range(1, 4)]
-
-    def prepare_titles(self, obj):
-        if obj.pk == 'uuid-1':
-            return ['object one title one', 'object one title two']
-        elif obj.pk == 'uuid-2':
-            return ['object two title one', 'object two title two']
-        else:
-            return ['object three title one', 'object three title two']
-
+        return models.UUIDModel
 
 
 class CompleteBlogEntryIndex(indexes.SearchIndex):

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -17,8 +17,8 @@ from haystack.models import SearchResult
 from haystack.utils.loading import UnifiedIndex
 
 from ..search_indexes import XapianNGramIndex, XapianEdgeNGramIndex, \
-    CompleteBlogEntryIndex, BlogSearchIndex, UUIDBlogSearchIndex
-from ..models import BlogEntry, AnotherMockModel, MockTag, UUIDBlogEntry
+    CompleteBlogEntryIndex, BlogSearchIndex, UUIDModelSearchIndex
+from ..models import BlogEntry, AnotherMockModel, MockTag, UUIDModel
 
 XAPIAN_VERSION = [int(x) for x in xapian.__version__.split('.')]
 
@@ -686,40 +686,21 @@ class StringBasedPKModelBackendFeaturesTestCase(HaystackBackendTestCase, TestCas
     """
 
     def get_index(self):
-        return UUIDBlogSearchIndex()
+        return UUIDModelSearchIndex()
 
     @staticmethod
     def get_entry(i):
-        entry = UUIDBlogEntry()
-        entry.uuid = 'uuid-%s' % i
-        entry.author = 'david%s' % i
-        entry.url = 'http://example.com/%d/' % i
-        entry.boolean = bool(i % 2)
-        entry.number = i*5
-        entry.float_number = i*5.0
-        entry.decimal_number = Decimal('22.34')
-        entry.datetime = (
-            datetime.datetime(2009, 2, 25, 1, 1, 1) - datetime.timedelta(seconds=i)
-        )
-        entry.date = datetime.date(2009, 2, 23) + datetime.timedelta(days=i)
+        entry = UUIDModel(uuid='uuid-%s' % i)
         return entry
 
     def setUp(self):
         super(StringBasedPKModelBackendFeaturesTestCase, self).setUp()
 
-        self.sample_objs = []
-
         for i in range(1, 4):
             entry = self.get_entry(i)
-            self.sample_objs.append(entry)
+            entry.save()
 
-        self.sample_objs[0].float_number = 834.0
-        self.sample_objs[1].float_number = 35.5
-        self.sample_objs[2].float_number = 972.0
-        for obj in self.sample_objs:
-            obj.save()
-
-        self.backend.update(self.index, UUIDBlogEntry.objects.all())
+        self.backend.update(self.index, UUIDModel.objects.all())
 
     def test_update(self):
         self.assertEqual(pks(self.backend.search(xapian.Query(''))['results']),
@@ -730,22 +711,21 @@ class StringBasedPKModelBackendFeaturesTestCase(HaystackBackendTestCase, TestCas
         We need this test because ordering on more than
         10 entries was not correct at some point.
         """
-        self.sample_objs = []
+        sample_objs = []
         pk_list = []
         for i in range(101, 200):
             entry = self.get_entry(i)
-            self.sample_objs.append(entry)
+            sample_objs.append(entry)
             pk_list.append('uuid-%03d' % i)
 
-        for obj in self.sample_objs:
+        for obj in sample_objs:
             obj.save()
 
         self.backend.clear()
-        self.backend.update(self.index, self.sample_objs)
+        self.backend.update(self.index, sample_objs)
 
         results = self.backend.search(xapian.Query(''), sort_by=['-django_id'])
         self.assertEqual(pks(results['results']), list(reversed(pk_list)))
-
 
 
 class IndexationNGramTestCase(HaystackBackendTestCase, TestCase):

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -1432,7 +1432,8 @@ class XapianSearchQuery(BaseSearchQuery):
 
         Assumes term is not a list.
         """
-        if field_type == 'text':
+        # `django_id` is not a normal text, and as such we should not use the phrase query.
+        if field_type == 'text' and field_name != 'django_id':
             term = '^ %s $' % term
             query = self._phrase_query(term.split(), field_name, field_type)
         else:


### PR DESCRIPTION
This addresses the missing text for searching. I had to add an extra condition to `xapian_backend.py` for the search on text-based ids be a exact search.

I also simplified the test models and indexes. See if you agree.